### PR TITLE
Fixed the routing issue for suggested videos

### DIFF
--- a/src/components/VideoPage.jsx
+++ b/src/components/VideoPage.jsx
@@ -200,7 +200,11 @@ const VideoPage = () => {
         )}
         {suggestData &&
           suggestData?.map((item, i) => {
-            return <Link to={item?.id} key={i}><SmallVideoCard data={item} /></Link>
+            return (
+              <Link to={`/watch/${item?.id}`} key={i}>
+                <SmallVideoCard data={item} />
+              </Link>
+            );
           })}
       </div>
     </div>


### PR DESCRIPTION
To fix this, you need to use an absolute path for the Link component. This means you should include the base path /watch/ before the item.id. 